### PR TITLE
Plat 1171 readme build

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Fitpay Corporation 
+Copyright (c) 2015-2016 Fitpay Inc. 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2016 Fitpay Corporation 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,47 @@
-# FitPay Android SDK
-[![Build Status](https://travis-ci.org/fitpay/fitpay-android.svg?branch=develop)](https://travis-ci.org/fitpay/fitpay-android)
+# FitPay Android SDK - README.md
 
-FitPay Android SDK Coming Soon....
+## Building the app
+
+### Building using Android Studio
+```
+mkdir fitpay  
+cd fitpay
+git clone git@github.com:fitpay/fitpay-android-sdk.git  
+cd fitpay-android-sdk
+studio.sh (or double click your android studio)
+Open an existing Android Studio project
+/home/yourname/fitpay/fitpay-android-sdk
+Click on Project (topleft), select Java, test, UserTest - right click and select "Run UserTest"
+```
+
+
+
+Fit-Pay also utilizes a continuous integration system (travis) to build and test. Current Develop Branch Status: [![Build Status](https://travis-ci.org/fitpay/fitpay-android-sdk.svg?branch=develop)](https://travis-ci.org/fitpay/fitpay-android-sdk)
+
+### Building from the commandline
+Ensure you have the Android SDK installed on your machine. http://developer.android.com/sdk/index.html  
+  
+Gradle also automagically runs the tests when you build.  
+
+```
+export ANDROID_HOME=/home/myname/Android/Sdk
+cd ~
+mkdir fitpay  
+cd fitpay
+git clone git@github.com:fitpay/fitpay-android-sdk.git  
+cd fitpay-android-sdk  
+./gradlew clean build  
+```
+
+### Problems with the tests?
+Some versions of Java come with an encryption distribution that may not be up to modern standards. If you experience problems with SSL connections, please download the [Java Cryptography Extension](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html).
+## Contributing to the SDK
+We welcome contributions to the SDK. For your first few contributions please fork the repo, make your changes and submit a pull request. Internally we branch off of develop, test, and PR-review the branch before merging to develop (moderately stable). Releases to Master happen less frequently, undergo more testing, and can be considered stable. For more information, please read:  [http://nvie.com/posts/a-successful-git-branching-model/](http://nvie.com/posts/a-successful-git-branching-model/)
+
+
+## License
+This code is licensed under the MIT license. More information can be found in the [LICENSE](LICENSE) file contained in this repository.
+
+## Questions? Comments? Concerns?
+Please contact the team via a github issue, OR, feel free to email us: sdk@fit-pay.com
+

--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,22 @@
 
 buildscript {
     repositories {
+        jcenter() // For Java 8 lint issues
         mavenCentral()
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:2.0.0'
         classpath 'me.tatarka:gradle-retrolambda:3.2.5'
+        // java 8 lint issues
+        classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
+
     }
+
+    // java 8 lint issues
+    // Exclude the version that the android plugin depends on.
+    configurations.classpath.exclude group: 'com.android.tools.external.lombok'
+
 }
 
 allprojects {

--- a/fitpay/src/test/java/com/fitpay/android/TestConstants.java
+++ b/fitpay/src/test/java/com/fitpay/android/TestConstants.java
@@ -30,7 +30,7 @@ public final class TestConstants {
     static Map<String, String> getConfig() {
         Map<String, String> env = System.getenv();
 
-        String currentEnv = System.getProperty("environment", "dev");
+        String currentEnv = System.getProperty("environment", "demo");
 
         Map<String, String>  config = new HashMap<>();
         switch (currentEnv) {


### PR DESCRIPTION
This does 3 things: Updates the license file, updates README.md, and changes our default build to demo instead of dev (both for CI and end users)

It also changes the build file for linting - to alleviate errors there