### PR TITLE
migrated stubsdk functionality for webview communicator and callback

### DIFF
--- a/fitpay/src/main/java/com/fitpay/android/webview/callback/OnTaskCompleted.java
+++ b/fitpay/src/main/java/com/fitpay/android/webview/callback/OnTaskCompleted.java
@@ -1,0 +1,6 @@
+package com.fitpay.android.webview.callback;
+
+
+public interface OnTaskCompleted {
+    void onTaskCompleted(String result);
+}

--- a/fitpay/src/main/java/com/fitpay/android/webview/impl/WebViewCommunicatorStubImpl.java
+++ b/fitpay/src/main/java/com/fitpay/android/webview/impl/WebViewCommunicatorStubImpl.java
@@ -3,13 +3,25 @@ package com.fitpay.android.webview.impl;
 import android.webkit.JavascriptInterface;
 
 import com.fitpay.android.webview.WebViewCommunicator;
+import  com.fitpay.android.webview.callback.OnTaskCompleted;
 
 import com.google.gson.Gson;
+import android.app.Activity;
+
 
 /**
+ * Created by Ross Gabay on 4/13/2016.
  * Stubbed out implementation of the WebViewCommunicator interface
  */
-public class WebViewCommunicatorStubImpl implements WebViewCommunicator{
+public class WebViewCommunicatorStubImpl implements WebViewCommunicator {
+
+    private final Activity activity;
+    private OnTaskCompleted callback;
+
+    public WebViewCommunicatorStubImpl(Activity ctx, OnTaskCompleted callback) {
+        this.activity = ctx;
+        this.callback = callback;
+    }
 
     private static String USER_DATA_STUB_RESPONSE = "OK";
     private static String SYNC_STUB_RESPONSE = "OK";
@@ -22,6 +34,7 @@ public class WebViewCommunicatorStubImpl implements WebViewCommunicator{
         AckResponseModel stubResponse = new AckResponseModel();
         stubResponse.setStatus(USER_DATA_STUB_RESPONSE);
 
+        callback.onTaskCompleted(SYNC_STUB_RESPONSE);
         return gson.toJson(stubResponse);
     }
 
@@ -41,3 +54,5 @@ public class WebViewCommunicatorStubImpl implements WebViewCommunicator{
         throw new UnsupportedOperationException("method not supported in this iteration");
     }
 }
+
+


### PR DESCRIPTION
migrated stubsdk functionality for webview communicator and callback to remove stubsdk dependency from the pagare android wv app.