### PR TITLE
Plat 2777 update android sdk readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ Now that you've built the repository, you need to tell your Android project wher
 3. Add the repository as a dependency to the module-level build.gradle file of your project.
     ```
     dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.fitpay.android:android_sdk:0.4.20'
+        compile fileTree(dir: 'libs', include: ['*.jar'])
+        compile 'com.fitpay.android:android_sdk:0.4.20'
+    }
     ```
 
 That's it! You are now able to build from your local repository.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Pre-built versions of the Android SDK are hosted on jcenter(). To use in your pr
         }
     }
     ```
-* add the pre-built SDK dependency, for example to use v0.5.0 of the SDK: ```compile 'com.fitpay.android:android_sdk:0.4.15'``` dependency to the ```dependencies``` closure of the build.gradle file.
+* add the pre-built SDK dependency, for example to use v0.5.0 of the SDK: ```compile 'com.fitpay.android:android_sdk:0.5.0'``` dependency to the ```dependencies``` closure of the build.gradle file.
     * Grab via Maven:
 
         ```xml
@@ -100,9 +100,11 @@ Pre-built versions of the Android SDK are hosted on jcenter(). To use in your pr
         ```
 
 ## Using local version of the SDK as a dependency for your build:
-You can build and use SDK from the local repository. So there are few ways how to do that:
+You can build and use SDK from the local repository. The first step is to build the local repository from the FitPay Android SDK by using a Gradle task included in the SDK. After running this task, a compiled version of the SDK will be outputted to a predefined folder on your machine ("LocalRepository") and will be available for use in your project.
 
-* Uploading using Android Studio
+You can build the repository from Android Studio or by using the commandline.
+
+* Build using Android Studio
 
     ```
     Open an existing Android Studio project
@@ -110,23 +112,23 @@ You can build and use SDK from the local repository. So there are few ways how t
     Click on Gradle (topright), select fitpay-android->Tasks->upload, uploadArchives - right click and select "Run fitpay-android[uploadArchives]"
     ```
 
-* Uploading from from the commandline
+* Build from the commandline
     ```
     Open an existing Android Studio project
     cd fitpay-android-sdk
     ./gradlew clean uploadArchives
     ```
 
-Now in your child project you should import the library from the local storage.
+Now that you've built the repository, you need to tell your Android project where it is located and that it needs to be included in your project. Open your Android project, and do the following:
 
-* First step. Add local repository to the top-level build.gradle
+* 1. Add the local repository's location to the top-level build.gradle file
     ```
     def localMavenRepository = 'file://' + new File(System.getProperty('user.home'), 'LocalRepository').absolutePath
     def String pbwURL = 'http://'
     def String metaDataURL = 'http://artifactory.fpctrl.com:8080/artifactory/repo/fitpay/pagare/maven-metadata.xml'
     ```
 
-* Second step. Make sure localMavenRepository() is listed in the ```repositories``` closure of your application's build.gradle file.
+* 2. Include ```localMavenRepository()``` in the ```repositories``` closure of the same top-level build.gradle file.
     ```
     allprojects {
         repositories {
@@ -134,6 +136,14 @@ Now in your child project you should import the library from the local storage.
         }
     }
      ```
+* 3. Add the repository as a dependency to the module-level build.gradle file of your project.
+    ```
+    dependencies {
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.fitpay.android:android_sdk:0.4.20'
+    ```
+
+That's it! You are now able to build from your local repository.
 
 ## Contributing to the SDK
 We welcome contributions to the SDK. For your first few contributions please fork the repo, make your changes and submit a pull request. Internally we branch off of develop, test, and PR-review the branch before merging to develop (moderately stable). Releases to Master happen less frequently, undergo more testing, and can be considered stable. For more information, please read:  [http://nvie.com/posts/a-successful-git-branching-model/](http://nvie.com/posts/a-successful-git-branching-model/)
@@ -157,4 +167,3 @@ This code is licensed under the MIT license. More information can be found in th
 
 ## Questions? Comments? Concerns?
 Please contact the team via a github issue, OR, feel free to email us: sdk@fit-pay.com
-

--- a/README.md
+++ b/README.md
@@ -121,14 +121,14 @@ You can build the repository from Android Studio or by using the commandline.
 
 Now that you've built the repository, you need to tell your Android project where it is located and that it needs to be included in your project. Open your Android project, and do the following:
 
-* 1. Add the local repository's location to the top-level build.gradle file
+1. Add the local repository's location to the top-level build.gradle file
     ```
     def localMavenRepository = 'file://' + new File(System.getProperty('user.home'), 'LocalRepository').absolutePath
     def String pbwURL = 'http://'
     def String metaDataURL = 'http://artifactory.fpctrl.com:8080/artifactory/repo/fitpay/pagare/maven-metadata.xml'
     ```
 
-* 2. Include ```localMavenRepository()``` in the ```repositories``` closure of the same top-level build.gradle file.
+2. Include ```localMavenRepository()``` in the ```repositories``` closure of the same top-level build.gradle file.
     ```
     allprojects {
         repositories {
@@ -136,7 +136,7 @@ Now that you've built the repository, you need to tell your Android project wher
         }
     }
      ```
-* 3. Add the repository as a dependency to the module-level build.gradle file of your project.
+3. Add the repository as a dependency to the module-level build.gradle file of your project.
     ```
     dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])

--- a/README.md
+++ b/README.md
@@ -100,21 +100,24 @@ Pre-built versions of the Android SDK are hosted on jcenter(). To use in your pr
         ```
 
 ## Using local version of the SDK as a dependency for your build:
-You can build and use SDK from the local repository. The first step is to build the local repository from the FitPay Android SDK by using a Gradle task included in the SDK. After running this task, a compiled version of the SDK will be outputted to a predefined folder on your machine ("LocalRepository") and will be available for use in your project.
+In order to use a local version of the SDK in your project, you need to first build the local repository by using the Gradle task ```uploadArchives``` that's included in the FitPay Android SDK. After running this task, the compiled SDK will be outputted to a local folder on your computer ("LocalRepository") and will be available for use in your project.
 
-You can build the repository from Android Studio or by using the commandline.
+You can run the Gradle task and build the repository from Android Studio or from the commandline.
 
 * Build using Android Studio
 
     ```
-    Open an existing Android Studio project
+    Open the FitPay Android SDK in Android Studio
+
     /home/yourname/fitpay/fitpay-android-sdk
+
     Click on Gradle (topright), select fitpay-android->Tasks->upload, uploadArchives - right click and select "Run fitpay-android[uploadArchives]"
     ```
 
 * Build from the commandline
     ```
-    Open an existing Android Studio project
+    Open the FitPay Android SDK in your commandline
+
     cd fitpay-android-sdk
     ./gradlew clean uploadArchives
     ```


### PR DESCRIPTION
Clarified that when building from the local repository, our steps lead to including the compiled SDK into your project and not including the source code, which I believe is what was causing Garmin's issues. 