### PR TITLE
Deprecating tow handling in sdk

### DIFF
--- a/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/PaymentDeviceConnector.java
+++ b/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/PaymentDeviceConnector.java
@@ -10,7 +10,6 @@ import com.fitpay.android.api.models.apdu.ApduCommand;
 import com.fitpay.android.api.models.apdu.ApduCommandResult;
 import com.fitpay.android.api.models.apdu.ApduExecutionResult;
 import com.fitpay.android.api.models.apdu.ApduPackage;
-import com.fitpay.android.api.models.card.CreditCard;
 import com.fitpay.android.api.models.card.TopOfWallet;
 import com.fitpay.android.api.models.device.Commit;
 import com.fitpay.android.api.models.user.User;
@@ -33,13 +32,10 @@ import com.fitpay.android.utils.RxBus;
 import com.fitpay.android.utils.TimestampUtils;
 
 import java.io.SyncFailedException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
-import rx.Observable;
 
 import static com.fitpay.android.paymentdevice.constants.ApduConstants.NORMAL_PROCESSING;
 import static com.fitpay.android.utils.Constants.APDU_DATA;
@@ -303,46 +299,22 @@ public abstract class PaymentDeviceConnector implements IPaymentDeviceConnector 
     }
 
     /**
+     * @deprecated the SDK handling have TOW as commits is no longer supported, TOW data can still be pulled
+     * from the CreditCard API resource when needed.
+     *
      * Get TOW data from the server
      */
     protected final void getTopOfWalletData(List<String> cardOrder) {
-        if (user == null) {
-            FPLog.w(TAG, "skipping getTopOfWalletData() handling, no user present in device");
-            return;
-        }
+     }
 
-        Map<String, TopOfWallet> cardMap = new HashMap<String, TopOfWallet>();
-        List<TopOfWallet> tow = new ArrayList<>();
-
-        user.getAllCreditCards().flatMap(creditCardCollection -> {
-            if (creditCardCollection.getResults() != null) {
-                for (CreditCard card : creditCardCollection.getResults()) {
-                    if (card.getTOW() != null) {
-                        cardMap.put(card.getCreditCardId(), card.getTOW());
-                    }
-                }
-                if (!cardMap.isEmpty()) {
-                    for (String cardId : cardOrder) {
-                        if (cardMap.containsKey(cardId)) {
-                            tow.add(cardMap.get(cardId));
-                        }
-                    }
-                }
-            }
-            return Observable.just(tow);
-        }).subscribe(
-                topOfWallets -> {
-                    if (topOfWallets != null && topOfWallets.size() > 0) {
-                        executeTopOfWallet(topOfWallets);
-                        RxBus.getInstance().post(topOfWallets);
-                    } else {
-                        commitProcessed(CommitResult.SUCCESS, null);
-                    }
-                },
-                throwable -> {
-                    FPLog.e(TAG, "TOW execution error: " + throwable.getMessage());
-                    commitProcessed(CommitResult.FAILED, throwable);
-                });
+    /**
+     * @deprecated See {@link IPaymentDeviceConnector} - providing a do-nothing implementation to help clean up OEM integrations
+     *
+     * @param towPackages
+     */
+    @Override
+    public void executeTopOfWallet(List<TopOfWallet> towPackages) {
+        FPLog.w(TAG, "deprecated executeTopOfWallet() still being called, please refactor to remove usage of PaymentDeviceConnect#executeTopOfWallet()");
     }
 
     /**

--- a/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/mock/MockPaymentDeviceConnector.java
+++ b/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/mock/MockPaymentDeviceConnector.java
@@ -27,19 +27,15 @@ import com.fitpay.android.utils.NotificationManager;
 import com.fitpay.android.utils.RxBus;
 import com.google.gson.Gson;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import rx.Observable;
 import rx.Observer;
-
-import static org.bouncycastle.asn1.x500.style.RFC4519Style.c;
 
 /**
  * Created by tgs on 5/3/16.
@@ -350,7 +346,6 @@ public class MockPaymentDeviceConnector extends PaymentDeviceConnector {
 
             switch (syncEvent.getState()) {
                 case States.COMPLETED:
-                    getTopOfWalletData(new ArrayList(getWallet().keySet()));
                     break;
 
                 case States.COMPLETED_NO_UPDATES:

--- a/fitpay/src/main/java/com/fitpay/android/paymentdevice/interfaces/IPaymentDeviceConnector.java
+++ b/fitpay/src/main/java/com/fitpay/android/paymentdevice/interfaces/IPaymentDeviceConnector.java
@@ -96,7 +96,10 @@ public interface IPaymentDeviceConnector extends CommitHandler {
     void sendApduExecutionResult(ApduExecutionResult apduExecutionResult);
 
     /**
-     * send top of wallet to the payment device
+     * @deprecated At this time we're looking to move away from the SDK specifically managing TOW execution:
+     *
+     * 1. This typically occurs on the wearable device and not within the mobile SDK
+     * 2. When not occuring on the wearable, the TOW are really nothing more than APDU_PACKAGEs and can be treated as such in an integration
      *
      * @param towPackages top of wallet package
      */

--- a/fitpay/src/test/java/com/fitpay/android/paymentdevice/impl/DeviceSyncManagerTest.java
+++ b/fitpay/src/test/java/com/fitpay/android/paymentdevice/impl/DeviceSyncManagerTest.java
@@ -285,11 +285,7 @@ public class DeviceSyncManagerTest extends TestActions {
                     .filter(syncEvent -> syncEvent.getState() == States.COMPLETED_NO_UPDATES || syncEvent.getState() == States.COMPLETED)
                     .count());
 
-        /**
-         * Why 6 commits vs. only the 3 that the system emits?   The android sdk for some reason is running TOW commands and emitting
-         * commitsuccess events
-         */
-        assertEquals(6,
+        assertEquals(3,
                 listener.getCommits().stream()
                     .filter(commit -> commit.getCommitType().equals("APDU_PACKAGE"))
                     .count());


### PR DESCRIPTION
There will be a pagare specific PR to correct for this change.  We need to get away from the SDK managing TOW like this, it's really confusing to our OEMs.   The fact the SDK wasn't finishing SYNC was because it "assumed" the SDK would issue the commit success even though it's commit handler was handling the commits.   Again, very confusing.