### PR TITLE
Fix auth check public access

### DIFF
--- a/fitpay/src/main/java/com/fitpay/android/api/ApiManager.java
+++ b/fitpay/src/main/java/com/fitpay/android/api/ApiManager.java
@@ -204,7 +204,7 @@ public class ApiManager {
         return config.get(PROPERTY_AUTH_BASE_URL);
     }
 
-    private boolean isAuthorized(@NonNull ApiCallback callback) {
+    public boolean isAuthorized(@NonNull ApiCallback callback) {
         if (!apiService.isAuthorized()) {
             callback.onFailure(ResultCode.UNAUTHORIZED, "Unauthorized");
 


### PR DESCRIPTION
Need to have public access for `ApiManager.isAuthorized()` to be able check authToken in client’s code because authToken doesn’t survive application reinstall. 
So we can store it locally and set via `ApiManager.setAuthToken(...)` if somehow token will be erased from `apiService`