### PR TITLE
Downgraded minSDKVersion to 18

### DIFF
--- a/fitpay/build.gradle
+++ b/fitpay/build.gradle
@@ -58,7 +58,7 @@ android {
     buildToolsVersion '27.0.3'
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 18
         targetSdkVersion 27
     }
 

--- a/fitpay/src/main/java/com/fitpay/android/webview/models/WvConfig.java
+++ b/fitpay/src/main/java/com/fitpay/android/webview/models/WvConfig.java
@@ -2,10 +2,9 @@ package com.fitpay.android.webview.models;
 
 import android.util.Base64;
 
-import com.fitpay.android.webview.models.a2a.A2AIssuerResponse;
 import com.google.gson.Gson;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 
 /**
@@ -21,7 +20,7 @@ public class WvConfig {
     }
 
     public String getEncodedString() {
-        byte[] bytesToEncode = toString().getBytes(StandardCharsets.UTF_8);
+        byte[] bytesToEncode = toString().getBytes(Charset.forName("UTF-8"));
         return Base64.encodeToString(bytesToEncode, Base64.URL_SAFE);
     }
 

--- a/fitpay/src/main/java/com/fitpay/android/webview/models/a2a/A2AIssuerResponse.java
+++ b/fitpay/src/main/java/com/fitpay/android/webview/models/a2a/A2AIssuerResponse.java
@@ -6,7 +6,7 @@ import com.fitpay.android.webview.enums.A2AStepupResult;
 import com.fitpay.android.webview.events.a2a.A2AVerificationRequest;
 import com.google.gson.Gson;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 /**
  * Issuer response data for {@link A2AVerificationRequest}
@@ -31,7 +31,7 @@ public class A2AIssuerResponse {
     }
 
     public String getEncodedString() {
-        byte[] bytesToEncode = toString().getBytes(StandardCharsets.UTF_8);
+        byte[] bytesToEncode = toString().getBytes(Charset.forName("UTF-8"));
         return Base64.encodeToString(bytesToEncode, Base64.URL_SAFE);
     }
 }


### PR DESCRIPTION
Due to not to drop users with 18 API we suggest to downgrade minSDKVersion to 18 and get rid of lint-bewared NewAPI calls, because there are only a few