### PR TITLE
PLAT-6992

### DIFF
--- a/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/mock/SecureElementDataProvider.java
+++ b/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/mock/SecureElementDataProvider.java
@@ -52,7 +52,7 @@ public class SecureElementDataProvider {
         buf.append("60A4"); // IC Module Packaging Date
         buf.append("0057"); // IC Manufacturer - 0057 is NXP
         buf.append("4272"); // IC EMbedding Date
-        buf.append("0823"); // PrePerso Id
+        buf.append("0051"); // PrePerso Id
         buf.append("6250"); // PrePerso Date
         buf.append("08246250"); // PrePerso Equipment
         buf.append("2041"); // Perso Id

--- a/fitpay/src/test/java/com/fitpay/android/Steps.java
+++ b/fitpay/src/test/java/com/fitpay/android/Steps.java
@@ -705,7 +705,7 @@ public class Steps extends BaseTestActions {
                 .setPairingTs(pairingTs)
                 .setSecureElement(new PaymentDevice.SecureElement(
                         SecureElementDataProvider.generateCasd(),
-                        "70B1A5000002000BA3035287D96A34D2E62CB23060A40057427208236250082462502041625008256250"))
+                        "70B1A5000002000BA3035287D96A34D2E62CB23060A40057427200516250082462502041625008256250"))
                 .build();
 
         final String[] errors = {""};


### PR DESCRIPTION
An attempt was made to replace the DEADBEEF test CPLC with the new one (70B1A500). I also replaced all instances of the ST manufacturer code (0823) with an NXP one (0051). This was mostly a failure. No source code (or binary files) have DEADBEEF, but for some inexplicable reason it still pops up in the logs when you run the tests. It's not pulling it from the API b/c I ran the tests locally with wifi turned off, and it still managed to pull DEADBEEF from somewhere. 