### PR TITLE
Swat 54

### DIFF
--- a/fitpay/src/main/java/com/fitpay/android/api/models/security/AccessDenied.java
+++ b/fitpay/src/main/java/com/fitpay/android/api/models/security/AccessDenied.java
@@ -24,13 +24,25 @@ public class AccessDenied {
     @Reason
     private final int reason;
 
+    private final boolean tokenRefreshRequired;
+
     private AccessDenied(int reason) {
         this.reason = reason;
+        this.tokenRefreshRequired = false;
+    }
+
+    private AccessDenied(int reason, boolean tokenRefreshRequired) {
+        this.reason = reason;
+        this.tokenRefreshRequired = tokenRefreshRequired;
     }
 
     @Reason
     public int getReason() {
         return reason;
+    }
+
+    public boolean isTokenRefreshRequired() {
+        return tokenRefreshRequired;
     }
 
     public static AccessDenied.Builder builder() {
@@ -40,14 +52,20 @@ public class AccessDenied {
     public static class Builder {
         @Reason
         private int reason;
+        private boolean tokenRefreshRequired;
 
         public AccessDenied.Builder reason(@Reason int reason) {
             this.reason = reason;
             return this;
         }
 
+        public AccessDenied.Builder tokenRefreshRequired(boolean tokenRefreshRequired) {
+            this.tokenRefreshRequired = tokenRefreshRequired;
+            return this;
+        }
+
         public AccessDenied build() {
-            return new AccessDenied(reason);
+            return new AccessDenied(reason, tokenRefreshRequired);
         }
     }
 }

--- a/fitpay/src/main/java/com/fitpay/android/api/services/FitPayService.java
+++ b/fitpay/src/main/java/com/fitpay/android/api/services/FitPayService.java
@@ -140,7 +140,7 @@ final public class FitPayService extends GenericClient<FitPayClient> {
     }
 
     public boolean isAuthorized() {
-        return mAuthToken != null;
+        return mAuthToken != null && !mAuthToken.isExpired();
     }
 
     public PlatformConfig getPlatformConfig() {

--- a/fitpay/src/main/java/com/fitpay/android/api/services/FitPayService.java
+++ b/fitpay/src/main/java/com/fitpay/android/api/services/FitPayService.java
@@ -57,7 +57,7 @@ final public class FitPayService extends GenericClient<FitPayClient> {
                     if (mAuthToken.isExpired()) {
                         if (expiredNotificationSent) {
                             // if the expired token was already used, reject it before making an API call
-                            FPLog.w("access token is expired, rejecting token usage until refreshed");
+                            FPLog.w("access token is expired, rejecting token usage until refreshed for request: " + chain.request().url());
                             RxBus.getInstance().post(AccessDenied.builder()
                                     .reason(AccessDenied.Reason.EXPIRED_TOKEN)
                                     .tokenRefreshRequired(true)
@@ -66,7 +66,7 @@ final public class FitPayService extends GenericClient<FitPayClient> {
                         } else {
                             // let the first expired token usage through to also trigger unauthorized message
                             expiredNotificationSent = true;
-                            FPLog.w("current access token is expired, using anyways");
+                            FPLog.w("current access token is expired, using anyways for request: " + chain.request().url());
                             RxBus.getInstance().post(AccessDenied.builder()
                                     .reason(AccessDenied.Reason.EXPIRED_TOKEN)
                                     .build());

--- a/fitpay/src/main/java/com/fitpay/android/api/services/FitPayService.java
+++ b/fitpay/src/main/java/com/fitpay/android/api/services/FitPayService.java
@@ -140,7 +140,7 @@ final public class FitPayService extends GenericClient<FitPayClient> {
     }
 
     public boolean isAuthorized() {
-        return mAuthToken != null && !mAuthToken.isExpired();
+        return mAuthToken != null;
     }
 
     public PlatformConfig getPlatformConfig() {

--- a/fitpay/src/main/java/com/fitpay/android/utils/ExpiredTokenException.java
+++ b/fitpay/src/main/java/com/fitpay/android/utils/ExpiredTokenException.java
@@ -1,0 +1,13 @@
+package com.fitpay.android.utils;
+
+import java.io.IOException;
+
+public class ExpiredTokenException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ExpiredTokenException(String message) {
+        super(message);
+    }
+
+}

--- a/fitpay/src/test/java/com/fitpay/android/api/models/security/BearerTokenTest.java
+++ b/fitpay/src/test/java/com/fitpay/android/api/models/security/BearerTokenTest.java
@@ -6,6 +6,7 @@ import com.fitpay.android.api.callbacks.ApiCallback;
 import com.fitpay.android.api.enums.ResultCode;
 import com.fitpay.android.api.models.user.User;
 import com.fitpay.android.utils.FPLog;
+import com.fitpay.android.utils.KeysManager;
 import com.fitpay.android.utils.Listener;
 import com.fitpay.android.utils.NamedResource;
 import com.fitpay.android.utils.NotificationManager;
@@ -19,6 +20,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Created by ssteveli on 10/5/17.
@@ -46,11 +49,13 @@ public class BearerTokenTest extends BaseTestActions {
     }
 
     @Test
-    public void testExpiredToken() throws Exception {
+    public void testExpiredTokenTriggerAccessDeniedEvents() throws Exception {
         OAuthToken token = new OAuthToken.Builder()
                 .accessToken("eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MmMwOWY5YS1mYWRmLTQyZDUtOGYzZC0zN2M4NTI2MTllY2YiLCJzdWIiOiIwYWQxMmEwNC0yZDc0LTRmYjUtYjFmMi00ZmVkZjcwMGRlMGQiLCJzY29wZSI6WyJ1c2VyLnJlYWQiLCJ1c2VyLndyaXRlIiwidHJhbnNhY3Rpb25zLnJlYWQiLCJkZXZpY2VzLndyaXRlIiwiZGV2aWNlcy5yZWFkIiwib3JnYW5pemF0aW9ucy5GSVRQQVkiLCJjcmVkaXRDYXJkcy53cml0ZSIsImNyZWRpdENhcmRzLnJlYWQiXSwiY2xpZW50X2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiY2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiYXpwIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlcl9pZCI6IjBhZDEyYTA0LTJkNzQtNGZiNS1iMWYyLTRmZWRmNzAwZGUwZCIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSFmcF93ZWJhcHBfcEprVnAyUmwiLCJlbWFpbCI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSIsImF1dGhfdGltZSI6MTUwNTMyMDM3NCwicmV2X3NpZyI6IjU5MzQ5Njc1IiwiaWF0IjoxNTA1MzIwMzc0LCJleHAiOjE1MDUzNjM1NzQsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC91YWEvb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlciIsInRyYW5zYWN0aW9ucyIsImRldmljZXMiLCJvcmdhbml6YXRpb25zIiwiY3JlZGl0Q2FyZHMiXX0.Z6WP2EIZR7jumtqfPboCPczJf-CR3I6RF498UlNQPsVuOV9bVbK1o0UjhVWYUnKQEfc_Ujirp_z8Eb6jeDx1eFyDN6cvFV9Bp0UJrvPBO79gCL3jeu0yb-M1mESTYKuoyk5rDa4_jW_1gI9BKDX8UXAEICaELasQRv4fgG0zGcua-f-FJJywtkvLc3PEaZP2xN8wpcUL053jg2QaNjgGWH_YWN3krj43gnAcgt9rOVZlTJKSGpED0Np4bq8IHZa6FBh-aFG0OzO3VWilMHiwFDLTEIlgrfVvV5-7_JKXDDDgy9ukbtmbzth1xPVBVNlxKS7K6tSlvttJ3esRuYMUqw")
                 .build();
 
+        // set a mock key pair to avoid intercepted additional API call to create key pair
+        KeysManager.getInstance().createPairForType(KeysManager.KEY_API);
         ApiManager.getInstance().setAuthToken(token);
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -75,13 +80,98 @@ public class BearerTokenTest extends BaseTestActions {
         latch.await();
         Assert.assertEquals("incorrect number for response codes captured", 1, codes.size());
         Assert.assertEquals(new Integer(AccessDenied.INVALID_TOKEN_RESPONSE_CODE), codes.get(0));
-
-        //EXPIRED_TOKEN will be received only once after commit: limited the number of expired token events (#156)
         Assert.assertEquals("access denied not posted to RxBus", 2, listener.getReceived().size());
-        Assert.assertEquals(AccessDenied.Reason.EXPIRED_TOKEN, listener.getReceived().get(0).getReason()); // key setup
-        //Assert.assertEquals(AccessDenied.Reason.EXPIRED_TOKEN, listener.getReceived().get(1).getReason()); // getting user
-        Assert.assertEquals(AccessDenied.Reason.UNAUTHORIZED, listener.getReceived().get(1).getReason()); // denied get user
+        Assert.assertEquals(AccessDenied.Reason.EXPIRED_TOKEN, listener.getReceived().get(0).getReason());
+        Assert.assertEquals(AccessDenied.Reason.UNAUTHORIZED, listener.getReceived().get(1).getReason());
+    }
 
+    @Test
+    public void testExpiredTokenRefreshResetsInterceptor() throws Exception {
+        OAuthToken token = new OAuthToken.Builder()
+                .accessToken("eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MmMwOWY5YS1mYWRmLTQyZDUtOGYzZC0zN2M4NTI2MTllY2YiLCJzdWIiOiIwYWQxMmEwNC0yZDc0LTRmYjUtYjFmMi00ZmVkZjcwMGRlMGQiLCJzY29wZSI6WyJ1c2VyLnJlYWQiLCJ1c2VyLndyaXRlIiwidHJhbnNhY3Rpb25zLnJlYWQiLCJkZXZpY2VzLndyaXRlIiwiZGV2aWNlcy5yZWFkIiwib3JnYW5pemF0aW9ucy5GSVRQQVkiLCJjcmVkaXRDYXJkcy53cml0ZSIsImNyZWRpdENhcmRzLnJlYWQiXSwiY2xpZW50X2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiY2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiYXpwIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlcl9pZCI6IjBhZDEyYTA0LTJkNzQtNGZiNS1iMWYyLTRmZWRmNzAwZGUwZCIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSFmcF93ZWJhcHBfcEprVnAyUmwiLCJlbWFpbCI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSIsImF1dGhfdGltZSI6MTUwNTMyMDM3NCwicmV2X3NpZyI6IjU5MzQ5Njc1IiwiaWF0IjoxNTA1MzIwMzc0LCJleHAiOjE1MDUzNjM1NzQsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC91YWEvb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlciIsInRyYW5zYWN0aW9ucyIsImRldmljZXMiLCJvcmdhbml6YXRpb25zIiwiY3JlZGl0Q2FyZHMiXX0.Z6WP2EIZR7jumtqfPboCPczJf-CR3I6RF498UlNQPsVuOV9bVbK1o0UjhVWYUnKQEfc_Ujirp_z8Eb6jeDx1eFyDN6cvFV9Bp0UJrvPBO79gCL3jeu0yb-M1mESTYKuoyk5rDa4_jW_1gI9BKDX8UXAEICaELasQRv4fgG0zGcua-f-FJJywtkvLc3PEaZP2xN8wpcUL053jg2QaNjgGWH_YWN3krj43gnAcgt9rOVZlTJKSGpED0Np4bq8IHZa6FBh-aFG0OzO3VWilMHiwFDLTEIlgrfVvV5-7_JKXDDDgy9ukbtmbzth1xPVBVNlxKS7K6tSlvttJ3esRuYMUqw")
+                .build();
+
+        // set a mock key pair to avoid intercepted additional API call to create key pair
+        KeysManager.getInstance().createPairForType(KeysManager.KEY_API);
+        ApiManager.getInstance().setAuthToken(token);
+
+        for (int i = 0; i < 2; i++) {
+            CountDownLatch latch = new CountDownLatch(1);
+            ApiManager.getInstance().getUser(new ApiCallback<User>() {
+                @Override
+                public void onSuccess(User result) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void onFailure(@ResultCode.Code int errorCode, String errorMessage) {
+                    latch.countDown();
+
+                }
+            });
+            latch.await();
+        }
+
+        List<AccessDenied> tokenRefreshRequired = listener.getReceived().stream()
+                .filter(e -> e.getReason() == AccessDenied.Reason.EXPIRED_TOKEN)
+                .filter(AccessDenied::isTokenRefreshRequired)
+                .collect(Collectors.toList());
+
+        Assert.assertEquals("should have 1 refresh required", 1, tokenRefreshRequired.size());
+        listener.cleanReceived();
+
+        // resetting the token should reset the interceptor
+        ApiManager.getInstance().setAuthToken(token);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        ApiManager.getInstance().getUser(new ApiCallback<User>() {
+            @Override
+            public void onSuccess(User result) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(@ResultCode.Code int errorCode, String errorMessage) {
+                FPLog.e(errorMessage);
+                latch.countDown();
+
+            }
+        });
+        latch.await();
+
+        tokenRefreshRequired = listener.getReceived().stream()
+                .filter(AccessDenied::isTokenRefreshRequired)
+                .collect(Collectors.toList());
+
+        Assert.assertEquals("should have 1 refresh required", 0, tokenRefreshRequired.size());
+    }
+
+    @Test
+    public void testExpiredTokenDoesNotResultInEndlessRetry() throws Exception {
+        OAuthToken token = new OAuthToken.Builder()
+                .accessToken("eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MmMwOWY5YS1mYWRmLTQyZDUtOGYzZC0zN2M4NTI2MTllY2YiLCJzdWIiOiIwYWQxMmEwNC0yZDc0LTRmYjUtYjFmMi00ZmVkZjcwMGRlMGQiLCJzY29wZSI6WyJ1c2VyLnJlYWQiLCJ1c2VyLndyaXRlIiwidHJhbnNhY3Rpb25zLnJlYWQiLCJkZXZpY2VzLndyaXRlIiwiZGV2aWNlcy5yZWFkIiwib3JnYW5pemF0aW9ucy5GSVRQQVkiLCJjcmVkaXRDYXJkcy53cml0ZSIsImNyZWRpdENhcmRzLnJlYWQiXSwiY2xpZW50X2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiY2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiYXpwIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlcl9pZCI6IjBhZDEyYTA0LTJkNzQtNGZiNS1iMWYyLTRmZWRmNzAwZGUwZCIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSFmcF93ZWJhcHBfcEprVnAyUmwiLCJlbWFpbCI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSIsImF1dGhfdGltZSI6MTUwNTMyMDM3NCwicmV2X3NpZyI6IjU5MzQ5Njc1IiwiaWF0IjoxNTA1MzIwMzc0LCJleHAiOjE1MDUzNjM1NzQsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC91YWEvb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlciIsInRyYW5zYWN0aW9ucyIsImRldmljZXMiLCJvcmdhbml6YXRpb25zIiwiY3JlZGl0Q2FyZHMiXX0.Z6WP2EIZR7jumtqfPboCPczJf-CR3I6RF498UlNQPsVuOV9bVbK1o0UjhVWYUnKQEfc_Ujirp_z8Eb6jeDx1eFyDN6cvFV9Bp0UJrvPBO79gCL3jeu0yb-M1mESTYKuoyk5rDa4_jW_1gI9BKDX8UXAEICaELasQRv4fgG0zGcua-f-FJJywtkvLc3PEaZP2xN8wpcUL053jg2QaNjgGWH_YWN3krj43gnAcgt9rOVZlTJKSGpED0Np4bq8IHZa6FBh-aFG0OzO3VWilMHiwFDLTEIlgrfVvV5-7_JKXDDDgy9ukbtmbzth1xPVBVNlxKS7K6tSlvttJ3esRuYMUqw")
+                .build();
+
+        // set a mock key pair to avoid intercepted additional API call to create key pair
+        KeysManager.getInstance().createPairForType(KeysManager.KEY_API);
+        ApiManager.getInstance().setAuthToken(token);
+
+        CountDownLatch latch = new CountDownLatch(5);
+        ApiManager.getInstance().getUser(new ApiCallback<User>() {
+            @Override
+            public void onSuccess(User result) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(@ResultCode.Code int errorCode, String errorMessage) {
+                latch.countDown();
+
+            }
+        });
+
+        latch.await(3000, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("should only have triggered one failure", 4, latch.getCount());
     }
 
     private class AccessDeniedListener extends Listener {
@@ -97,6 +187,10 @@ public class BearerTokenTest extends BaseTestActions {
 
         public List<AccessDenied> getReceived() {
             return received;
+        }
+
+        public void cleanReceived() {
+            received.clear();
         }
     }
 }

--- a/fitpay/src/test/java/com/fitpay/android/api/models/security/BearerTokenTest.java
+++ b/fitpay/src/test/java/com/fitpay/android/api/models/security/BearerTokenTest.java
@@ -173,24 +173,6 @@ public class BearerTokenTest extends BaseTestActions {
         Assert.assertEquals("should only have triggered one failure", 4, latch.getCount());
     }
 
-    @Test
-    public void testFitPayServiceTokenAuth() {
-        FitPayService fitPayService = new FitPayService(FitpayConfig.apiURL);
-
-        // Expired token should be unauthorized even it's set
-        OAuthToken token = genExpiredToken();
-        fitPayService.updateToken(token);
-        Assert.assertFalse("expired token should not be authorized", fitPayService.isAuthorized());
-
-        // Token that is not expired should be authorized
-        token = new OAuthToken.Builder()
-            .accessToken("eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MmMwOWY5YS1mYWRmLTQyZDUtOGYzZC0zN2M4NTI2MTllY2YiLCJzdWIiOiIwYWQxMmEwNC0yZDc0LTRmYjUtYjFmMi00ZmVkZjcwMGRlMGQiLCJzY29wZSI6WyJ1c2VyLnJlYWQiLCJ1c2VyLndyaXRlIiwidHJhbnNhY3Rpb25zLnJlYWQiLCJkZXZpY2VzLndyaXRlIiwiZGV2aWNlcy5yZWFkIiwib3JnYW5pemF0aW9ucy5GSVRQQVkiLCJjcmVkaXRDYXJkcy53cml0ZSIsImNyZWRpdENhcmRzLnJlYWQiXSwiY2xpZW50X2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiY2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiYXpwIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlcl9pZCI6IjBhZDEyYTA0LTJkNzQtNGZiNS1iMWYyLTRmZWRmNzAwZGUwZCIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSFmcF93ZWJhcHBfcEprVnAyUmwiLCJlbWFpbCI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSIsImF1dGhfdGltZSI6MTUwNTMyMDM3NCwicmV2X3NpZyI6IjU5MzQ5Njc1IiwiaWF0IjoxNTA1MzIwMzc0LCJleHAiOjE1MDUzNjM1NzQsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC91YWEvb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlciIsInRyYW5zYWN0aW9ucyIsImRldmljZXMiLCJvcmdhbml6YXRpb25zIiwiY3JlZGl0Q2FyZHMiXX0.Z6WP2EIZR7jumtqfPboCPczJf-CR3I6RF498UlNQPsVuOV9bVbK1o0UjhVWYUnKQEfc_Ujirp_z8Eb6jeDx1eFyDN6cvFV9Bp0UJrvPBO79gCL3jeu0yb-M1mESTYKuoyk5rDa4_jW_1gI9BKDX8UXAEICaELasQRv4fgG0zGcua-f-FJJywtkvLc3PEaZP2xN8wpcUL053jg2QaNjgGWH_YWN3krj43gnAcgt9rOVZlTJKSGpED0Np4bq8IHZa6FBh-aFG0OzO3VWilMHiwFDLTEIlgrfVvV5-7_JKXDDDgy9ukbtmbzth1xPVBVNlxKS7K6tSlvttJ3esRuYMUqw")
-            .expiredTs(new Date(System.currentTimeMillis() + 10000))
-            .build();
-        fitPayService.updateToken(token);
-        Assert.assertTrue("not expired token should be authorized", fitPayService.isAuthorized());
-    }
-
     private OAuthToken genExpiredToken() {
         return new OAuthToken.Builder()
             .accessToken("eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MmMwOWY5YS1mYWRmLTQyZDUtOGYzZC0zN2M4NTI2MTllY2YiLCJzdWIiOiIwYWQxMmEwNC0yZDc0LTRmYjUtYjFmMi00ZmVkZjcwMGRlMGQiLCJzY29wZSI6WyJ1c2VyLnJlYWQiLCJ1c2VyLndyaXRlIiwidHJhbnNhY3Rpb25zLnJlYWQiLCJkZXZpY2VzLndyaXRlIiwiZGV2aWNlcy5yZWFkIiwib3JnYW5pemF0aW9ucy5GSVRQQVkiLCJjcmVkaXRDYXJkcy53cml0ZSIsImNyZWRpdENhcmRzLnJlYWQiXSwiY2xpZW50X2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiY2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiYXpwIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlcl9pZCI6IjBhZDEyYTA0LTJkNzQtNGZiNS1iMWYyLTRmZWRmNzAwZGUwZCIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSFmcF93ZWJhcHBfcEprVnAyUmwiLCJlbWFpbCI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSIsImF1dGhfdGltZSI6MTUwNTMyMDM3NCwicmV2X3NpZyI6IjU5MzQ5Njc1IiwiaWF0IjoxNTA1MzIwMzc0LCJleHAiOjE1MDUzNjM1NzQsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC91YWEvb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlciIsInRyYW5zYWN0aW9ucyIsImRldmljZXMiLCJvcmdhbml6YXRpb25zIiwiY3JlZGl0Q2FyZHMiXX0.Z6WP2EIZR7jumtqfPboCPczJf-CR3I6RF498UlNQPsVuOV9bVbK1o0UjhVWYUnKQEfc_Ujirp_z8Eb6jeDx1eFyDN6cvFV9Bp0UJrvPBO79gCL3jeu0yb-M1mESTYKuoyk5rDa4_jW_1gI9BKDX8UXAEICaELasQRv4fgG0zGcua-f-FJJywtkvLc3PEaZP2xN8wpcUL053jg2QaNjgGWH_YWN3krj43gnAcgt9rOVZlTJKSGpED0Np4bq8IHZa6FBh-aFG0OzO3VWilMHiwFDLTEIlgrfVvV5-7_JKXDDDgy9ukbtmbzth1xPVBVNlxKS7K6tSlvttJ3esRuYMUqw")

--- a/fitpay/src/test/java/com/fitpay/android/api/models/security/BearerTokenTest.java
+++ b/fitpay/src/test/java/com/fitpay/android/api/models/security/BearerTokenTest.java
@@ -5,6 +5,8 @@ import com.fitpay.android.api.ApiManager;
 import com.fitpay.android.api.callbacks.ApiCallback;
 import com.fitpay.android.api.enums.ResultCode;
 import com.fitpay.android.api.models.user.User;
+import com.fitpay.android.api.services.FitPayService;
+import com.fitpay.android.configs.FitpayConfig;
 import com.fitpay.android.utils.FPLog;
 import com.fitpay.android.utils.KeysManager;
 import com.fitpay.android.utils.Listener;
@@ -18,6 +20,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -87,9 +90,7 @@ public class BearerTokenTest extends BaseTestActions {
 
     @Test
     public void testExpiredTokenRefreshResetsInterceptor() throws Exception {
-        OAuthToken token = new OAuthToken.Builder()
-                .accessToken("eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MmMwOWY5YS1mYWRmLTQyZDUtOGYzZC0zN2M4NTI2MTllY2YiLCJzdWIiOiIwYWQxMmEwNC0yZDc0LTRmYjUtYjFmMi00ZmVkZjcwMGRlMGQiLCJzY29wZSI6WyJ1c2VyLnJlYWQiLCJ1c2VyLndyaXRlIiwidHJhbnNhY3Rpb25zLnJlYWQiLCJkZXZpY2VzLndyaXRlIiwiZGV2aWNlcy5yZWFkIiwib3JnYW5pemF0aW9ucy5GSVRQQVkiLCJjcmVkaXRDYXJkcy53cml0ZSIsImNyZWRpdENhcmRzLnJlYWQiXSwiY2xpZW50X2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiY2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiYXpwIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlcl9pZCI6IjBhZDEyYTA0LTJkNzQtNGZiNS1iMWYyLTRmZWRmNzAwZGUwZCIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSFmcF93ZWJhcHBfcEprVnAyUmwiLCJlbWFpbCI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSIsImF1dGhfdGltZSI6MTUwNTMyMDM3NCwicmV2X3NpZyI6IjU5MzQ5Njc1IiwiaWF0IjoxNTA1MzIwMzc0LCJleHAiOjE1MDUzNjM1NzQsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC91YWEvb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlciIsInRyYW5zYWN0aW9ucyIsImRldmljZXMiLCJvcmdhbml6YXRpb25zIiwiY3JlZGl0Q2FyZHMiXX0.Z6WP2EIZR7jumtqfPboCPczJf-CR3I6RF498UlNQPsVuOV9bVbK1o0UjhVWYUnKQEfc_Ujirp_z8Eb6jeDx1eFyDN6cvFV9Bp0UJrvPBO79gCL3jeu0yb-M1mESTYKuoyk5rDa4_jW_1gI9BKDX8UXAEICaELasQRv4fgG0zGcua-f-FJJywtkvLc3PEaZP2xN8wpcUL053jg2QaNjgGWH_YWN3krj43gnAcgt9rOVZlTJKSGpED0Np4bq8IHZa6FBh-aFG0OzO3VWilMHiwFDLTEIlgrfVvV5-7_JKXDDDgy9ukbtmbzth1xPVBVNlxKS7K6tSlvttJ3esRuYMUqw")
-                .build();
+        OAuthToken token = genExpiredToken();
 
         // set a mock key pair to avoid intercepted additional API call to create key pair
         KeysManager.getInstance().createPairForType(KeysManager.KEY_API);
@@ -148,9 +149,7 @@ public class BearerTokenTest extends BaseTestActions {
 
     @Test
     public void testExpiredTokenDoesNotResultInEndlessRetry() throws Exception {
-        OAuthToken token = new OAuthToken.Builder()
-                .accessToken("eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MmMwOWY5YS1mYWRmLTQyZDUtOGYzZC0zN2M4NTI2MTllY2YiLCJzdWIiOiIwYWQxMmEwNC0yZDc0LTRmYjUtYjFmMi00ZmVkZjcwMGRlMGQiLCJzY29wZSI6WyJ1c2VyLnJlYWQiLCJ1c2VyLndyaXRlIiwidHJhbnNhY3Rpb25zLnJlYWQiLCJkZXZpY2VzLndyaXRlIiwiZGV2aWNlcy5yZWFkIiwib3JnYW5pemF0aW9ucy5GSVRQQVkiLCJjcmVkaXRDYXJkcy53cml0ZSIsImNyZWRpdENhcmRzLnJlYWQiXSwiY2xpZW50X2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiY2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiYXpwIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlcl9pZCI6IjBhZDEyYTA0LTJkNzQtNGZiNS1iMWYyLTRmZWRmNzAwZGUwZCIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSFmcF93ZWJhcHBfcEprVnAyUmwiLCJlbWFpbCI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSIsImF1dGhfdGltZSI6MTUwNTMyMDM3NCwicmV2X3NpZyI6IjU5MzQ5Njc1IiwiaWF0IjoxNTA1MzIwMzc0LCJleHAiOjE1MDUzNjM1NzQsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC91YWEvb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlciIsInRyYW5zYWN0aW9ucyIsImRldmljZXMiLCJvcmdhbml6YXRpb25zIiwiY3JlZGl0Q2FyZHMiXX0.Z6WP2EIZR7jumtqfPboCPczJf-CR3I6RF498UlNQPsVuOV9bVbK1o0UjhVWYUnKQEfc_Ujirp_z8Eb6jeDx1eFyDN6cvFV9Bp0UJrvPBO79gCL3jeu0yb-M1mESTYKuoyk5rDa4_jW_1gI9BKDX8UXAEICaELasQRv4fgG0zGcua-f-FJJywtkvLc3PEaZP2xN8wpcUL053jg2QaNjgGWH_YWN3krj43gnAcgt9rOVZlTJKSGpED0Np4bq8IHZa6FBh-aFG0OzO3VWilMHiwFDLTEIlgrfVvV5-7_JKXDDDgy9ukbtmbzth1xPVBVNlxKS7K6tSlvttJ3esRuYMUqw")
-                .build();
+        OAuthToken token = genExpiredToken();
 
         // set a mock key pair to avoid intercepted additional API call to create key pair
         KeysManager.getInstance().createPairForType(KeysManager.KEY_API);
@@ -172,6 +171,30 @@ public class BearerTokenTest extends BaseTestActions {
 
         latch.await(3000, TimeUnit.MILLISECONDS);
         Assert.assertEquals("should only have triggered one failure", 4, latch.getCount());
+    }
+
+    @Test
+    public void testFitPayServiceTokenAuth() {
+        FitPayService fitPayService = new FitPayService(FitpayConfig.apiURL);
+
+        // Expired token should be unauthorized even it's set
+        OAuthToken token = genExpiredToken();
+        fitPayService.updateToken(token);
+        Assert.assertFalse("expired token should not be authorized", fitPayService.isAuthorized());
+
+        // Token that is not expired should be authorized
+        token = new OAuthToken.Builder()
+            .accessToken("eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MmMwOWY5YS1mYWRmLTQyZDUtOGYzZC0zN2M4NTI2MTllY2YiLCJzdWIiOiIwYWQxMmEwNC0yZDc0LTRmYjUtYjFmMi00ZmVkZjcwMGRlMGQiLCJzY29wZSI6WyJ1c2VyLnJlYWQiLCJ1c2VyLndyaXRlIiwidHJhbnNhY3Rpb25zLnJlYWQiLCJkZXZpY2VzLndyaXRlIiwiZGV2aWNlcy5yZWFkIiwib3JnYW5pemF0aW9ucy5GSVRQQVkiLCJjcmVkaXRDYXJkcy53cml0ZSIsImNyZWRpdENhcmRzLnJlYWQiXSwiY2xpZW50X2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiY2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiYXpwIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlcl9pZCI6IjBhZDEyYTA0LTJkNzQtNGZiNS1iMWYyLTRmZWRmNzAwZGUwZCIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSFmcF93ZWJhcHBfcEprVnAyUmwiLCJlbWFpbCI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSIsImF1dGhfdGltZSI6MTUwNTMyMDM3NCwicmV2X3NpZyI6IjU5MzQ5Njc1IiwiaWF0IjoxNTA1MzIwMzc0LCJleHAiOjE1MDUzNjM1NzQsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC91YWEvb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlciIsInRyYW5zYWN0aW9ucyIsImRldmljZXMiLCJvcmdhbml6YXRpb25zIiwiY3JlZGl0Q2FyZHMiXX0.Z6WP2EIZR7jumtqfPboCPczJf-CR3I6RF498UlNQPsVuOV9bVbK1o0UjhVWYUnKQEfc_Ujirp_z8Eb6jeDx1eFyDN6cvFV9Bp0UJrvPBO79gCL3jeu0yb-M1mESTYKuoyk5rDa4_jW_1gI9BKDX8UXAEICaELasQRv4fgG0zGcua-f-FJJywtkvLc3PEaZP2xN8wpcUL053jg2QaNjgGWH_YWN3krj43gnAcgt9rOVZlTJKSGpED0Np4bq8IHZa6FBh-aFG0OzO3VWilMHiwFDLTEIlgrfVvV5-7_JKXDDDgy9ukbtmbzth1xPVBVNlxKS7K6tSlvttJ3esRuYMUqw")
+            .expiredTs(new Date(System.currentTimeMillis() + 10000))
+            .build();
+        fitPayService.updateToken(token);
+        Assert.assertTrue("not expired token should be authorized", fitPayService.isAuthorized());
+    }
+
+    private OAuthToken genExpiredToken() {
+        return new OAuthToken.Builder()
+            .accessToken("eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiI0MmMwOWY5YS1mYWRmLTQyZDUtOGYzZC0zN2M4NTI2MTllY2YiLCJzdWIiOiIwYWQxMmEwNC0yZDc0LTRmYjUtYjFmMi00ZmVkZjcwMGRlMGQiLCJzY29wZSI6WyJ1c2VyLnJlYWQiLCJ1c2VyLndyaXRlIiwidHJhbnNhY3Rpb25zLnJlYWQiLCJkZXZpY2VzLndyaXRlIiwiZGV2aWNlcy5yZWFkIiwib3JnYW5pemF0aW9ucy5GSVRQQVkiLCJjcmVkaXRDYXJkcy53cml0ZSIsImNyZWRpdENhcmRzLnJlYWQiXSwiY2xpZW50X2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiY2lkIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwiYXpwIjoiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlcl9pZCI6IjBhZDEyYTA0LTJkNzQtNGZiNS1iMWYyLTRmZWRmNzAwZGUwZCIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSFmcF93ZWJhcHBfcEprVnAyUmwiLCJlbWFpbCI6InNjb3R0K25ld3dhbGxldEBmaXQtcGF5LmNvbSIsImF1dGhfdGltZSI6MTUwNTMyMDM3NCwicmV2X3NpZyI6IjU5MzQ5Njc1IiwiaWF0IjoxNTA1MzIwMzc0LCJleHAiOjE1MDUzNjM1NzQsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC91YWEvb2F1dGgvdG9rZW4iLCJ6aWQiOiJ1YWEiLCJhdWQiOlsiZnBfd2ViYXBwX3BKa1ZwMlJsIiwidXNlciIsInRyYW5zYWN0aW9ucyIsImRldmljZXMiLCJvcmdhbml6YXRpb25zIiwiY3JlZGl0Q2FyZHMiXX0.Z6WP2EIZR7jumtqfPboCPczJf-CR3I6RF498UlNQPsVuOV9bVbK1o0UjhVWYUnKQEfc_Ujirp_z8Eb6jeDx1eFyDN6cvFV9Bp0UJrvPBO79gCL3jeu0yb-M1mESTYKuoyk5rDa4_jW_1gI9BKDX8UXAEICaELasQRv4fgG0zGcua-f-FJJywtkvLc3PEaZP2xN8wpcUL053jg2QaNjgGWH_YWN3krj43gnAcgt9rOVZlTJKSGpED0Np4bq8IHZa6FBh-aFG0OzO3VWilMHiwFDLTEIlgrfVvV5-7_JKXDDDgy9ukbtmbzth1xPVBVNlxKS7K6tSlvttJ3esRuYMUqw")
+            .build();
     }
 
     private class AccessDeniedListener extends Listener {


### PR DESCRIPTION
This change will make it so when an SDK client continually uses an expired token we will skip API calls, but the same events will still be published to the bus and the error will still be propagated through any callbacks. This is only a partial solution to SWAT-54. Finding the root cause behind what continually triggers the usage of an expired token is still an open topic, and after talking with @climbonbelay we are going to wait for some updates from GCM so we have more info to work with.