### PR TITLE
fpSDK crashes GCM if payload is null

### DIFF
--- a/fitpay/src/main/java/com/fitpay/android/api/models/device/CommitModel.java
+++ b/fitpay/src/main/java/com/fitpay/android/api/models/device/CommitModel.java
@@ -32,7 +32,10 @@ abstract class CommitModel extends BaseModel {
     }
 
     public Object getPayload() {
-        return payload.getData(commitType);
+        if (payload != null) {
+            return payload.getData(commitType);
+        }
+        return null;
     }
 
     @Override

--- a/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/PaymentDeviceConnector.java
+++ b/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/PaymentDeviceConnector.java
@@ -8,6 +8,7 @@ import com.fitpay.android.api.callbacks.ApiCallback;
 import com.fitpay.android.api.enums.CommitTypes;
 import com.fitpay.android.api.enums.ResponseState;
 import com.fitpay.android.api.enums.ResultCode;
+import com.fitpay.android.api.models.Payload;
 import com.fitpay.android.api.models.apdu.ApduCommand;
 import com.fitpay.android.api.models.apdu.ApduCommandResult;
 import com.fitpay.android.api.models.apdu.ApduExecutionResult;
@@ -550,6 +551,12 @@ public abstract class PaymentDeviceConnector implements PaymentDeviceConnectable
         @Override
         public void processCommit(Commit commit) {
             Object payload = commit.getPayload();
+
+            if (payload == null) {
+                FPLog.e(TAG, "processCommit: payload is null, can not process commit...");
+                return;
+            }
+
             if (payload instanceof ApduPackage) {
                 ApduPackage pkg = (ApduPackage) payload;
 

--- a/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/mock/MockPaymentDeviceConnector.java
+++ b/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/mock/MockPaymentDeviceConnector.java
@@ -289,6 +289,19 @@ public class MockPaymentDeviceConnector extends PaymentDeviceConnector {
         @Override
         public void processCommit(Commit commit) {
             Object payload = commit.getPayload();
+
+            // case where payload is null
+            if (payload == null) {
+                FPLog.e(TAG, "Mock Wallet received a commit with null payload data, Commit: " + commit);
+                postData(new CommitFailed.Builder()
+                        .commit(commit)
+                        .errorCode(99)
+                        .errorMessage("Commit commit payload is null")
+                        .build());
+
+                return;
+            }
+
             if (!(payload instanceof CreditCardCommit)) {
                 FPLog.e(TAG, "Mock Wallet received a commit to process that was not a credit card commit.  Commit: " + commit);
                 postData(new CommitFailed.Builder()
@@ -321,6 +334,19 @@ public class MockPaymentDeviceConnector extends PaymentDeviceConnector {
         @Override
         public void processCommit(Commit commit) {
             Object payload = commit.getPayload();
+
+            // case where payload is null
+            if (payload == null) {
+                FPLog.e(TAG, "Mock Wallet received a commit with null payload data, Commit: " + commit);
+                postData(new CommitFailed.Builder()
+                        .commit(commit)
+                        .errorCode(99)
+                        .errorMessage("Commit commit payload is null")
+                        .build());
+
+                return;
+            }
+
             if (!(payload instanceof CreditCardCommit)) {
                 FPLog.e(TAG, "Mock Wallet received a commit to process that was not a credit card commit.  Commit: " + commit);
                 postData(new CommitFailed.Builder()

--- a/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/mock/MockPaymentDeviceConnector.java
+++ b/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/mock/MockPaymentDeviceConnector.java
@@ -292,24 +292,12 @@ public class MockPaymentDeviceConnector extends PaymentDeviceConnector {
 
             // case where payload is null
             if (payload == null) {
-                FPLog.e(TAG, "Mock Wallet received a commit with null payload data, Commit: " + commit);
-                postData(new CommitFailed.Builder()
-                        .commit(commit)
-                        .errorCode(99)
-                        .errorMessage("Commit commit payload is null")
-                        .build());
-
+                reportPayloadNull(commit);
                 return;
             }
 
             if (!(payload instanceof CreditCardCommit)) {
-                FPLog.e(TAG, "Mock Wallet received a commit to process that was not a credit card commit.  Commit: " + commit);
-                postData(new CommitFailed.Builder()
-                        .commit(commit)
-                        .errorCode(999)
-                        .errorMessage("Commit does not contain a credit card")
-                        .build());
-
+                reportInvalidPayload(commit);
                 return;
             }
             // process with a delay to mock device response time
@@ -337,23 +325,12 @@ public class MockPaymentDeviceConnector extends PaymentDeviceConnector {
 
             // case where payload is null
             if (payload == null) {
-                FPLog.e(TAG, "Mock Wallet received a commit with null payload data, Commit: " + commit);
-                postData(new CommitFailed.Builder()
-                        .commit(commit)
-                        .errorCode(99)
-                        .errorMessage("Commit commit payload is null")
-                        .build());
-
+                reportPayloadNull(commit);
                 return;
             }
 
             if (!(payload instanceof CreditCardCommit)) {
-                FPLog.e(TAG, "Mock Wallet received a commit to process that was not a credit card commit.  Commit: " + commit);
-                postData(new CommitFailed.Builder()
-                        .commit(commit)
-                        .errorCode(999)
-                        .errorMessage("Commit does not contain a credit card")
-                        .build());
+                reportInvalidPayload(commit);
                 return;
             }
 
@@ -370,5 +347,23 @@ public class MockPaymentDeviceConnector extends PaymentDeviceConnector {
                                 postData(new CommitFailed.Builder().commit(commit).build());
                             });
         }
+    }
+
+    private void reportPayloadNull(Commit commit) {
+        FPLog.e(TAG, "Mock Wallet received a commit with null payload data, Commit: " + commit);
+        postData(new CommitFailed.Builder()
+                .commit(commit)
+                .errorCode(99)
+                .errorMessage("Commit commit payload is null")
+                .build());
+    }
+
+    private void reportInvalidPayload(Commit commit) {
+        FPLog.e(TAG, "Mock Wallet received a commit to process that was not a credit card commit.  Commit: " + commit);
+        postData(new CommitFailed.Builder()
+                .commit(commit)
+                .errorCode(999)
+                .errorMessage("Commit does not contain a credit card")
+                .build());
     }
 }

--- a/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/mock/SecureElementDataProvider.java
+++ b/fitpay/src/main/java/com/fitpay/android/paymentdevice/impl/mock/SecureElementDataProvider.java
@@ -52,7 +52,7 @@ public class SecureElementDataProvider {
         buf.append("60A4"); // IC Module Packaging Date
         buf.append("0057"); // IC Manufacturer - 0057 is NXP
         buf.append("4272"); // IC EMbedding Date
-        buf.append("0823"); // PrePerso Id
+        buf.append("0051"); // PrePerso Id
         buf.append("6250"); // PrePerso Date
         buf.append("08246250"); // PrePerso Equipment
         buf.append("2041"); // Perso Id

--- a/fitpay/src/main/java/com/fitpay/android/utils/ModelAdapter.java
+++ b/fitpay/src/main/java/com/fitpay/android/utils/ModelAdapter.java
@@ -86,6 +86,11 @@ final class ModelAdapter {
 
                     return payload;
                 }
+                else {
+                    FPLog.w(TAG, "deserialize: decryptedString is empty, can not deserialize payload data");
+                }
+            } else {
+                FPLog.w(TAG, "deserialize: json is empty, can not deserialize payload data");
             }
 
             return null;

--- a/fitpay/src/test/java/com/fitpay/android/Steps.java
+++ b/fitpay/src/test/java/com/fitpay/android/Steps.java
@@ -705,7 +705,7 @@ public class Steps extends BaseTestActions {
                 .setPairingTs(pairingTs)
                 .setSecureElement(new PaymentDevice.SecureElement(
                         SecureElementDataProvider.generateCasd(),
-                        "70B1A5000002000BA3035287D96A34D2E62CB23060A40057427208236250082462502041625008256250"))
+                        "70B1A5000002000BA3035287D96A34D2E62CB23060A40057427200516250082462502041625008256250"))
                 .build();
 
         final String[] errors = {""};


### PR DESCRIPTION
* Avoid crash if the payload is null

Issue: https://jira.consumer.garmin.com/browse/CA-71035