### PR TITLE
Set userEventStreamsEnabled = true as default PlatformConfig

### DIFF
--- a/fitpay/src/main/java/com/fitpay/android/api/models/PlatformConfig.java
+++ b/fitpay/src/main/java/com/fitpay/android/api/models/PlatformConfig.java
@@ -5,7 +5,7 @@ package com.fitpay.android.api.models;
  * for dynamic SDK control of features/functionality.
  */
 public class PlatformConfig {
-    private boolean userEventStreamsEnabled;
+    private boolean userEventStreamsEnabled = true;
 
     /**
      * Can be used disable the user event stream from being initialized in the sdk


### PR DESCRIPTION
* in AQUA+VPN env, platformConfig api call is failing due to
SSL cert trust issue, fpSDK falls back to default in that case.
set userEventStreamsEnabled = true in order to receive stream events .

* had conversation with Todd and he mentioned this is a low risk task.

Issue: CA-77397